### PR TITLE
ksud: use MS_RDONLY when mounting overlayfs

### DIFF
--- a/userspace/ksud/src/mount.rs
+++ b/userspace/ksud/src/mount.rs
@@ -149,6 +149,7 @@ fn mount_overlayfs(
     Mount::builder()
         .fstype(FilesystemType::from("overlay"))
         .data(&options)
+        .flags(MountFlags::RDONLY)
         .mount(KSU_OVERLAY_SOURCE, dest.as_ref())
         .with_context(|| {
             format!(


### PR DESCRIPTION
fix https://github.com/tiann/KernelSU/issues/489