### PR TITLE
ksud: add KSU_MAGIC_MOUNT to env

### DIFF
--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -57,6 +57,7 @@ fn exec_install_script(module_file: &str) -> Result<()> {
         .env("KSU_KERNEL_VER_CODE", ksucalls::get_version().to_string())
         .env("KSU_VER", defs::VERSION_NAME)
         .env("KSU_VER_CODE", defs::VERSION_CODE)
+        .env("KSU_MAGIC_MOUNT", "true")
         .env("OUTFD", "1")
         .env("ZIPFILE", realpath)
         .status()?;
@@ -172,6 +173,7 @@ fn exec_script<T: AsRef<Path>>(path: T, wait: bool) -> Result<()> {
         .env("KSU_KERNEL_VER_CODE", ksucalls::get_version().to_string())
         .env("KSU_VER_CODE", defs::VERSION_CODE)
         .env("KSU_VER", defs::VERSION_NAME)
+        .env("KSU_MAGIC_MOUNT", "true")
         .env(
             "PATH",
             format!(


### PR DESCRIPTION
first of all, thanks for ksu magic mount man.


since this is not on mainline yet, having this will be useful in the meantime
( cannott just use KSU_VER_CODE -ge xxxx )
so some modules that are sensitive to manager's mount type can atleast differentiate.