### PR TITLE
kernel: core_hook: unconditional umount for /system/etc/hosts

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -553,6 +553,9 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	try_umount("/debug_ramdisk", false, MNT_DETACH);
 	try_umount("/sbin", false, MNT_DETACH);
 
+	// try umount /system/etc/hosts (hosts module)
+	try_umount("/system/etc/hosts", false, MNT_DETACH);
+
 	return 0;
 }
 


### PR DESCRIPTION
Modding hosts file is a common thing to have on rooted android devices. 
But this is easy to detect, either by reading the file, checking modified time and checking its filesize. 
Unmounting it as needed for non-root processes solves this issue.

Rejected: https://github.com/tiann/KernelSU/pull/1494
Merged in: https://github.com/rifsxd/KernelSU-Next/commit/7ea1579bce18e2641a4e182cfe70c5017e9dc825

This method will also work on nomount mode

very simple module template
[hosts.zip](https://github.com/user-attachments/files/18581729/hosts.zip)
