### PR TITLE
ksud: probe for more workdir candidates

### DIFF
--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -24,14 +24,12 @@ pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 
 pub const KSUD_VERBOSE_LOG_FILE: &str = concatcp!(ADB_DIR, "verbose");
 
-pub const TEMP_DIR: &str = "/debug_ramdisk";
 pub const MODULE_WEB_DIR: &str = "webroot";
 pub const MODULE_ACTION_SH: &str = "action.sh";
 pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";
 pub const REMOVE_FILE_NAME: &str = "remove";
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
-pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, "/workdir");
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,4 +1,4 @@
-use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR};
+use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH};
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};
@@ -69,7 +69,7 @@ pub fn on_post_data_fs() -> Result<()> {
 
     // mount temp dir
     if !Path::new(NO_TMPFS_PATH).exists() {
-        if let Err(e) = mount(KSU_MOUNT_SOURCE, TEMP_DIR, "tmpfs", MountFlags::empty(), "") {
+        if let Err(e) = mount(KSU_MOUNT_SOURCE, utils::get_tmp_path(), "tmpfs", MountFlags::empty(), "") {
             warn!("do temp dir mount failed: {}", e);
         }
     } else {

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -1,9 +1,9 @@
 use crate::defs::{
-    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MAGIC_MOUNT_WORK_DIR, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
+    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
 };
 use crate::magic_mount::NodeFileType::{Directory, RegularFile, Symlink, Whiteout};
 use crate::restorecon::{lgetfilecon, lsetfilecon};
-use crate::utils::ensure_dir_exists;
+use crate::utils::{ensure_dir_exists, get_work_dir};
 use anyhow::{Context, Result, bail};
 use extattr::lgetxattr;
 use rustix::fs::{
@@ -417,7 +417,7 @@ fn do_magic_mount<P: AsRef<Path>, WP: AsRef<Path>>(
 pub fn magic_mount() -> Result<()> {
     if let Some(root) = collect_module_files()? {
         log::debug!("collected: {:#?}", root);
-        let tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
+        let tmp_dir = PathBuf::from(get_work_dir());
         ensure_dir_exists(&tmp_dir)?;
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;


### PR DESCRIPTION
- reuses old ksu functions
- makes sure its an empty dir
- adapted from https://github.com/rsuntk/KernelSU/commit/141f010 https://github.com/tiann/KernelSU/commit/71cb86c2e9a9e1e9c323cf06dd287e8a69616904

context: 
https://imgur.com/a/ZRzc3YO
https://github.com/tiann/KernelSU/issues/539#issuecomment-2695006498
https://github.com/tiann/KernelSU/issues/539#issuecomment-2705516346


use MKSU on old devices without needing a full overlayfs backport.
but then /debug_ramdisk is not there!

Co-Authored-By: powellnorma <101364699+powellnorma@users.noreply.github.com>
Co-Authored-By: Rissu <90097027+rsuntk@users.noreply.github.com>
