### PR TITLE
kernel: core_hook: automate and refactor umount

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -704,10 +704,13 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
-	char buf[256];
+	// 384 is what throne_tracker uses, something sensible even for /data/app
+	// we can pattern match revanced mounts even.
+	// we are not really interested on mountpoints that are longer than that
+	char buf[384];
 	char *dir_name = d_path(path, buf, sizeof(buf));
-	
-	if (dir_name)
+
+	if (dir_name && dir_name != buf)
 		return ksu_mount_monitor(dev_name, dir_name, type);
 	else
 		return 0;

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -559,6 +559,7 @@ static void try_umount(const char *mnt, bool check_mnt, int flags)
 
 int ksu_handle_setuid(struct cred *new, const struct cred *old)
 {
+	char buf[256];
 	struct mount_entry *entry, *tmp;
 
 	// this hook is used for umounting overlayfs for some uid, if there isn't any module mounted, just ignore it!
@@ -612,7 +613,8 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 #endif
 
 	list_for_each_entry_safe(entry, tmp, &mount_list, list) {
-		ksu_umount_mnt(&entry->path, 0); 
+		char *actual_path = d_path(&entry->path, buf, sizeof(buf));
+		try_umount(actual_path, false, MNT_DETACH);
 	}
 	
 	try_umount("/data/adb/modules", false, MNT_DETACH);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -50,7 +50,6 @@ static bool ksu_module_mounted = false;
 extern int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 static bool ksu_su_compat_enabled = true;
-static bool ksu_mount_monitor_enabled = true;
 extern void ksu_sucompat_init();
 extern void ksu_sucompat_exit();
 
@@ -333,9 +332,6 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
 				pr_info("boot_complete triggered\n");
-				// turn off mount monitor
-				pr_info("turning off ksu_mount_monitor\n");
-				ksu_mount_monitor_enabled = false;
 			}
 			break;
 		}
@@ -596,10 +592,7 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *type) 
 {
-	if (!ksu_mount_monitor_enabled) {
-		return 0;
-	}
-
+	
 	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
 	char *fstype_copy = kstrdup(type, GFP_KERNEL);
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
@@ -711,10 +704,6 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
-	if (!ksu_mount_monitor_enabled) {
-		return 0;
-	}
-
 	// 384 is what throne_tracker uses, something sensible even for /data/app
 	// we can pattern match revanced mounts even.
 	// we are not really interested on mountpoints that are longer than that

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -600,12 +600,13 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
 	struct mount_entry *new_entry;
 	
-	if (!device_name_copy || !fstype_copy || !dirname_copy) {
+	if (!device_name_copy || !dirname_copy) {
 		goto out;
 	}
 	
-	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update
-	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") ) {
+	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update || MKSU magic mount
+	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") || 
+		( strstarts(device_name_copy, "/dev/workdir") && !strstarts(dirname_copy, "/dev/workdir")) || strstarts(device_name_copy, "/data/adb/modules") ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -662,6 +662,21 @@ static struct kprobe renameat_kp = {
 	.pre_handler = renameat_handler_pre,
 };
 
+
+static int mount_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+	const char *dev_name = (const char *)PT_REGS_PARM1(regs); 
+	const char *dir_name = (const char *)PT_REGS_PARM2(regs);
+ 	const char *type = (const char *)PT_REGS_PARM3(regs);
+
+	return ksu_mount_monitor(dev_name, dir_name, type);
+}
+
+static struct kprobe mount_hook_kp = {
+	.symbol_name = "do_mount",
+	.pre_handler = mount_handler_pre,
+};
+
 __maybe_unused int ksu_kprobe_init(void)
 {
 	int rc = 0;
@@ -900,6 +915,7 @@ void __init ksu_lsm_hook_init(void)
 	} else {
 		pr_warn("Failed to find task_fix_setuid!\n");
 	}
+	register_kprobe(&mount_hook_kp);
 	smp_mb();
 }
 #endif

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -50,6 +50,7 @@ static bool ksu_module_mounted = false;
 extern int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 static bool ksu_su_compat_enabled = true;
+static bool ksu_mount_monitor_enabled = true;
 extern void ksu_sucompat_init();
 extern void ksu_sucompat_exit();
 
@@ -332,6 +333,9 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
 				pr_info("boot_complete triggered\n");
+				// turn off mount monitor
+				pr_info("turning off ksu_mount_monitor\n");
+				ksu_mount_monitor_enabled = false;
 			}
 			break;
 		}
@@ -592,7 +596,10 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *type) 
 {
-	
+	if (!ksu_mount_monitor_enabled) {
+		return 0;
+	}
+
 	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
 	char *fstype_copy = kstrdup(type, GFP_KERNEL);
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
@@ -704,6 +711,10 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
+	if (!ksu_mount_monitor_enabled) {
+		return 0;
+	}
+
 	// 384 is what throne_tracker uses, something sensible even for /data/app
 	// we can pattern match revanced mounts even.
 	// we are not really interested on mountpoints that are longer than that

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -635,7 +635,7 @@ int ksu_mount_monitor(const char *dev_name, const struct path *path, const char 
 	}
 	
 	// overlay, overlayfs, change pattern later
-	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "pattern", 7) == 0) ) {
+	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "KSU", 3) == 0) ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->path = *path; 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -617,6 +617,12 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	return 0;
 }
 
+static int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
+{
+	pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", dev_name, type, path->dentry->d_iname);
+	return 0;
+}
+
 // Init functons
 
 static int handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -699,11 +705,18 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 	return ksu_handle_setuid(new, old);
 }
 
+static int ksu_sb_mount(const char *dev_name, const struct path *path,
+                        const char *type, unsigned long flags, void *data)
+{
+	return ksu_mount_monitor(dev_name, path, type);
+}
+
 #ifndef MODULE
 static struct security_hook_list ksu_hooks[] = {
 	LSM_HOOK_INIT(task_prctl, ksu_task_prctl),
 	LSM_HOOK_INIT(inode_rename, ksu_inode_rename),
 	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid),
+	LSM_HOOK_INIT(sb_mount, ksu_sb_mount),
 };
 
 void __init ksu_lsm_hook_init(void)

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -617,9 +617,28 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	return 0;
 }
 
-static int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
+int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
 {
-	pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", dev_name, type, path->dentry->d_iname);
+	// https://elixir.bootlin.com/linux/v4.14.336/source/include/linux/fs.h#L2083 ?
+	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
+	char *fstype_copy = kstrdup(type, GFP_KERNEL);
+	char *path_name_copy = kstrdup(path->dentry->d_iname, GFP_KERNEL);
+	
+	if (!device_name_copy || !fstype_copy || !path_name_copy) {
+		goto out;
+	}
+	
+	// overlay, overlayfs, change pattern later
+	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "pattern", 7) == 0) ) {
+		pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, path_name_copy);
+		// add me to list after
+		// better pass path struct
+	}
+	
+out:
+	kfree(device_name_copy);
+	kfree(fstype_copy);
+	kfree(path_name_copy);
 	return 0;
 }
 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -603,7 +603,7 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 	}
 	
 	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update
-	if ( ( !strncmp(device_name_copy, "KSU", 3) && ( strstr(fstype_copy, "overlay") || !strncmp(fstype_copy, "tmpfs", 5) ) ) || strstr(dirname_copy, "/data/adb/modules") ) {
+	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -525,8 +525,10 @@ static void try_umount(const char *mnt, int flags)
 	int val = path_umount(&path, flags);
 	if (val)
 		pr_info("umount %s failed: %d\n", mnt, val);
+#ifdef CONFIG_KSU_DEBUG
 	else
 		pr_info("umount %s success: %d\n", mnt, val);
+#endif
 }
 
 int ksu_handle_setuid(struct cred *new, const struct cred *old)
@@ -710,10 +712,14 @@ static int ksu_sb_mount(const char *dev_name, const struct path *path,
 	char buf[384];
 	char *dir_name = d_path(path, buf, sizeof(buf));
 
-	if (dir_name && dir_name != buf)
+	if (dir_name && dir_name != buf) {
+#ifdef CONFIG_KSU_DEBUG
+		pr_info("security_sb_mount: devname: %s path: %s type: %s \n", dev_name, dir_name, type);
+#endif
 		return ksu_mount_monitor(dev_name, dir_name, type);
-	else
+	} else {
 		return 0;
+	}
 }
 
 #ifndef MODULE

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -587,10 +587,8 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 		try_umount(entry->umountable, MNT_DETACH);
 	}
 
+	// unconditional umount for modules.img
 	try_umount("/data/adb/modules", MNT_DETACH);
-
-	// try umount ksu temp path
-	try_umount("/debug_ramdisk", MNT_DETACH);
 
 	return 0;
 }
@@ -606,13 +604,13 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 		goto out;
 	}
 	
-	// overlay, overlayfs, change pattern later
-	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "KSU", 3) == 0) ) {
+	// KSU devname, overlay/fs and tmpfs
+	if ( !strncmp(device_name_copy, "KSU", 3) && ( strstr(fstype_copy, "overlay") || !strncmp(fstype_copy, "tmpfs", 5) ) ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);
 			list_add(&new_entry->list, &mount_list);
-			pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, new_entry->umountable);
+			pr_info("ksu_mount_monitor: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, new_entry->umountable);
 		}
 	}
 out:

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -31,7 +31,7 @@ pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";
 pub const REMOVE_FILE_NAME: &str = "remove";
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
-pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, "/workdir");
+pub const MAGIC_MOUNT_WORK_DIR: &str = "/dev/workdir"; 
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -24,12 +24,14 @@ pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 
 pub const KSUD_VERBOSE_LOG_FILE: &str = concatcp!(ADB_DIR, "verbose");
 
+pub const TEMP_DIR: &str = "/debug_ramdisk";
 pub const MODULE_WEB_DIR: &str = "webroot";
 pub const MODULE_ACTION_SH: &str = "action.sh";
 pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";
 pub const REMOVE_FILE_NAME: &str = "remove";
 pub const SKIP_MOUNT_FILE_NAME: &str = "skip_mount";
+pub const MAGIC_MOUNT_WORK_DIR: &str = concatcp!(TEMP_DIR, "/workdir");
 
 pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
 pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,4 +1,4 @@
-use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH};
+use crate::defs::{KSU_MOUNT_SOURCE, NO_MOUNT_PATH, NO_TMPFS_PATH, TEMP_DIR};
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, ksucalls, restorecon, utils};
 use anyhow::{Context, Result};
@@ -69,7 +69,7 @@ pub fn on_post_data_fs() -> Result<()> {
 
     // mount temp dir
     if !Path::new(NO_TMPFS_PATH).exists() {
-        if let Err(e) = mount(KSU_MOUNT_SOURCE, utils::get_tmp_path(), "tmpfs", MountFlags::empty(), "") {
+        if let Err(e) = mount(KSU_MOUNT_SOURCE, TEMP_DIR, "tmpfs", MountFlags::empty(), "") {
             warn!("do temp dir mount failed: {}", e);
         }
     } else {

--- a/userspace/ksud/src/magic_mount.rs
+++ b/userspace/ksud/src/magic_mount.rs
@@ -1,9 +1,9 @@
 use crate::defs::{
-    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
+    DISABLE_FILE_NAME, KSU_MOUNT_SOURCE, MAGIC_MOUNT_WORK_DIR, MODULE_DIR, SKIP_MOUNT_FILE_NAME,
 };
 use crate::magic_mount::NodeFileType::{Directory, RegularFile, Symlink, Whiteout};
 use crate::restorecon::{lgetfilecon, lsetfilecon};
-use crate::utils::{ensure_dir_exists, get_work_dir};
+use crate::utils::ensure_dir_exists;
 use anyhow::{Context, Result, bail};
 use extattr::lgetxattr;
 use rustix::fs::{
@@ -417,7 +417,7 @@ fn do_magic_mount<P: AsRef<Path>, WP: AsRef<Path>>(
 pub fn magic_mount() -> Result<()> {
     if let Some(root) = collect_module_files()? {
         log::debug!("collected: {:#?}", root);
-        let tmp_dir = PathBuf::from(get_work_dir());
+        let tmp_dir = PathBuf::from(MAGIC_MOUNT_WORK_DIR);
         ensure_dir_exists(&tmp_dir)?;
         mount(KSU_MOUNT_SOURCE, &tmp_dir, "tmpfs", MountFlags::empty(), "").context("mount tmp")?;
         mount_change(&tmp_dir, MountPropagationFlags::PRIVATE).context("make tmp private")?;

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Error, Ok, Result, bail};
 use std::{
-    fs::{self, File, OpenOptions, create_dir_all, remove_file, write},
+    fs::{File, OpenOptions, create_dir_all, remove_file, write},
     io::{
         ErrorKind::{AlreadyExists, NotFound},
         Write,
@@ -175,38 +175,6 @@ pub fn umask(_mask: u32) {
 
 pub fn has_magisk() -> bool {
     which::which("magisk").is_ok()
-}
-
-fn is_ok_empty(dir: &str) -> bool {
-    use std::result::Result::Ok;
-
-    match fs::read_dir(dir) {
-        Ok(mut entries) => entries.next().is_none(),
-        Err(_) => false,
-    }
-}
-
-pub fn get_tmp_path() -> String {
-    let dirs = [
-        "/debug_ramdisk",
-        "/patch_hw",
-        "/oem",
-        "/root",
-        "/sbin",
-    ];
-
-    // find empty directory
-    for dir in dirs {
-        if is_ok_empty(dir) {
-            return dir.to_string();
-        }
-    }
-    "".to_string()
-}
-
-pub fn get_work_dir() -> String {
-     let tmp_path = get_tmp_path();
-     format!("{}/workdir/", tmp_path)
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
Mirror of: https://github.com/tiann/KernelSU/pull/2531

I can't really test for LKM, so that is something to check.
[DNM: untested kprobe hook for do_mount](https://github.com/5ec1cff/KernelSU/pull/13/commits/2eb8a7c62c833129fbe7e17fb23c9334ab5ff83f)

For integrated builds, (GKI / Manual hooks) this should be a non-issue since it is using LSM_HOOK_INIT.

